### PR TITLE
Breadcrumb with the orgNameShort

### DIFF
--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -1,4 +1,3 @@
-index.title=Search the ALA
 facet.conservationStatusAUS_s=Conservation status in Australia
 facet.conservationStatusACT_s=Conservation status in ACT
 facet.conservationStatusNSW_s=Conservation status in NSW

--- a/grails-app/views/layouts/ala.gsp
+++ b/grails-app/views/layouts/ala.gsp
@@ -4,7 +4,8 @@
     <head>
         <title><g:layoutTitle/></title>
         <meta name="breadcrumb" content="${pageProperty(name: 'meta.breadcrumb', default: pageProperty(name: 'title').split('\\|')[0].decodeHTML())}"/>
-        <meta name="breadcrumbParent" content="${pageProperty(name: 'meta.breadcrumbParent', default: "${createLink(uri: '/')},${message(code: 'index.title')}")}"/>
+        <meta name="breadcrumbParent" content="${pageProperty(name: 'meta.breadcrumbParent', default: "${createLink(uri: '/')},${message(code: 'page.index.heading', args: [orgNameShort])}")}"/>
+
         <script type="text/javascript">
             var BIE_VARS = { "autocompleteUrl" : "${grailsApplication.config.bie.index.url}/search/auto.jsonp"}
         </script>


### PR DESCRIPTION
Minor patch to use a breadcrumb with the `orgNameShort` instead of hardcoded ALA. 

For that I use `page.index.heading` message with org (from `bie-plugin`).

PS: I did this PR to master by error (#64)